### PR TITLE
sidebar: add dynamic menu

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+@tylucaskelley
+@aaron-suarez
+@rob-craig

--- a/functions.php
+++ b/functions.php
@@ -37,6 +37,19 @@ function remove_menu_pages() {
   
 };
 
+/**
+ * Customizable navigation menu
+ */
+function register_menus() {
+  register_nav_menus(
+    array(
+      'sidebar-menu' => __( 'Sidebar Menu' )
+    )
+  );
+}
+
+add_action( 'init', 'register_menus' );
+
 add_action( 'wp_ajax_signUp', 'signUp' );
 add_action( 'wp_ajax_nopriv_signUp', 'signUp' );
 

--- a/header.php
+++ b/header.php
@@ -106,18 +106,11 @@
 					<img itemprop="logo" alt="New Orleans Democratic Socialists of America" src="<?php echo get_bloginfo('template_directory');?>/library/images/dsa-new-orleans-logo-menu.png"/>
 						
 					<ul>
-						<!-- hardcoded menu items -->
 						<li class="first"><a href="<?php echo get_home_url(); ?>">Home</a></li>
-						<li><a href="<?php echo get_home_url(); ?>/covid-19-resources-for-workers/">COVID-19 Resources</a></li>
-						<li><a href="<?php echo get_home_url(); ?>/what-is-democratic-socialists-of-america/">What is DSA?</a></li>
-						<li><a href="<?php echo get_home_url(); ?>/red-delta/">Red Delta</a></li>
-						<li><a href="<?php echo get_home_url(); ?>/events/">Upcoming Events</a></li>
-						<li><a href="<?php echo get_home_url(); ?>/new-member-resources/">Member Resources</a></li>
-						<li><a href="<?php echo get_home_url(); ?>/accessibility/">Accessibility</a></li>
-						<li><a href="<?php echo get_home_url(); ?>/bylaws/">Chapter Bylaws</a></li>
-						<li><a href="https://donorbox.org/new-orleans-dsa-local-dues">Make a Local Donation</a></li> 
-						<li><a href="<?php echo get_home_url(); ?>/frequently-asked-questions/">Frequently Asked Questions</a></li> 
-						
+						<!-- dynamic sidebar menu -->
+						<?php
+						wp_nav_menu(array('theme_location' => 'sidebar-menu'));
+						?>
 						<!-- dynamic committee menu -->
 						<li class="menu-parent">
 							<span class="menu-sub-header">Committees</span>


### PR DESCRIPTION
Changeset:

- Removes hard-coded menu items in sidebar
- Utilizes `register_nav_menus` and `wp_nav_menu` functions to place a menu on the sidebar, which can then be customized in the wordpress admin dashboard
- Add CODEOWNERS file

![Screen Shot 2020-06-03 at 6 21 06 PM](https://user-images.githubusercontent.com/5448759/83698781-e78bdf80-a5c7-11ea-836b-48b86ca5c7a7.png)

![Screen Shot 2020-06-03 at 6 21 09 PM](https://user-images.githubusercontent.com/5448759/83698767-e22e9500-a5c7-11ea-99bd-e10f81621f7f.png)
